### PR TITLE
fix: Fix MIDI drum pattern generation by removing incorrect await calls

### DIFF
--- a/mcp_server/handlers/midi.py
+++ b/mcp_server/handlers/midi.py
@@ -141,7 +141,7 @@ The clip is ready for note input and will enforce the selected scale constraints
                     velocity = max(1, min(127, velocity))
                 
                 # Add note via OSC
-                await self.ableton_tools.osc_client.send(
+                self.ableton_tools.osc_client.send(
                     "/live/clip/add/notes",
                     track_id, clip_id, pitch, start_time, duration, velocity, int(mute)
                 )
@@ -214,7 +214,7 @@ The clip is ready for note input and will enforce the selected scale constraints
             
             # Remove existing note (using pitch as identifier for now)
             if pitch is not None:
-                await self.ableton_tools.osc_client.send(
+                self.ableton_tools.osc_client.send(
                     "/live/clip/remove/notes",
                     track_id, clip_id, note_id, start_time or 0, duration or 1
                 )
@@ -225,7 +225,7 @@ The clip is ready for note input and will enforce the selected scale constraints
             final_start = start_time if start_time is not None else 0.0
             final_duration = duration if duration is not None else 1.0
             
-            await self.ableton_tools.osc_client.send(
+            self.ableton_tools.osc_client.send(
                 "/live/clip/add/notes",
                 track_id, clip_id, final_pitch, final_start, final_duration, final_velocity, 0
             )

--- a/mcp_server/handlers/samples.py
+++ b/mcp_server/handlers/samples.py
@@ -364,35 +364,35 @@ class SamplesHandler:
             for param_name, value in parameters.items():
                 if param_name.lower() == "gain":
                     # Set clip gain (0.0 to 1.0, where 0.75 = 0dB)
-                    await self.ableton_tools.osc_client.send(
+                    self.ableton_tools.osc_client.send(
                         "/live/clip/set/gain", track_id, clip_id, float(value)
                     )
                     applied_params.append(f"Gain: {value:.2f} ({self._gain_to_db(value):.1f} dB)")
                 
                 elif param_name.lower() == "start_marker":
                     # Set clip start position
-                    await self.ableton_tools.osc_client.send(
+                    self.ableton_tools.osc_client.send(
                         "/live/clip/set/start_marker", track_id, clip_id, float(value)
                     )
                     applied_params.append(f"Start Marker: {value:.3f} beats")
                 
                 elif param_name.lower() == "end_marker":
                     # Set clip end position
-                    await self.ableton_tools.osc_client.send(
+                    self.ableton_tools.osc_client.send(
                         "/live/clip/set/end_marker", track_id, clip_id, float(value)
                     )
                     applied_params.append(f"End Marker: {value:.3f} beats")
                 
                 elif param_name.lower() == "loop_start":
                     # Set loop start point
-                    await self.ableton_tools.osc_client.send(
+                    self.ableton_tools.osc_client.send(
                         "/live/clip/set/loop_start", track_id, clip_id, float(value)
                     )
                     applied_params.append(f"Loop Start: {value:.3f} beats")
                 
                 elif param_name.lower() == "loop_end":
                     # Set loop end point
-                    await self.ableton_tools.osc_client.send(
+                    self.ableton_tools.osc_client.send(
                         "/live/clip/set/loop_end", track_id, clip_id, float(value)
                     )
                     applied_params.append(f"Loop End: {value:.3f} beats")
@@ -466,12 +466,12 @@ class SamplesHandler:
                 return [{"type": "text", "text": f"❌ Invalid warp mode '{warp_mode}'. Valid modes: {', '.join(valid_modes)}"}]
             
             # Set warp mode via OSC (this would need specific OSC commands)
-            await self.ableton_tools.osc_client.send(
+            self.ableton_tools.osc_client.send(
                 "/live/clip/set/warp_mode", track_id, clip_id, warp_mode
             )
             
             if preserve_formants:
-                await self.ableton_tools.osc_client.send(
+                self.ableton_tools.osc_client.send(
                     "/live/clip/set/preserve_formants", track_id, clip_id, 1
                 )
             


### PR DESCRIPTION
Fixes #2 - MIDI drum patterns not being created

## Problem
The `generate_drum_pattern` function was reporting success but not creating actual MIDI content in Ableton Live.

## Solution
Removed incorrect `await` keywords from `osc_client.send()` calls. The send method is synchronous, not async.

## Changes
- Fixed 3 instances in `midi.py`
- Fixed 7 instances in `samples.py`

## Testing
After this fix, drum patterns and melodies should be properly created in Ableton Live clips.

Generated with [Claude Code](https://claude.ai/code)